### PR TITLE
chore(deps): update to textlint-rule-ja-no-mixed-period@2.1.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1533,9 +1533,9 @@
       }
     },
     "textlint-rule-ja-no-mixed-period": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/textlint-rule-ja-no-mixed-period/-/textlint-rule-ja-no-mixed-period-2.1.0.tgz",
-      "integrity": "sha512-81nO2SRRA7QQ1gZaM0WnNNXt54C69wXIyZ4AcWuLpiTVVdK24M89V5Ju/i7O8hBuol8RiXJXK675IrubB9YQug==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/textlint-rule-ja-no-mixed-period/-/textlint-rule-ja-no-mixed-period-2.1.1.tgz",
+      "integrity": "sha512-yCfRva4pl2Sa6Xsxhzkec9rGuqP4MBlGrQ7ZQIM9On9dMaeIVabcwniMbLfO1CzUBBe9xUaCF/8eE0zOi8g4/A==",
       "dev": true,
       "requires": {
         "check-ends-with-period": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "devDependencies": {
     "textlint": "^11.0.1",
     "textlint-plugin-review": "^0.3.3",
-    "textlint-rule-ja-no-mixed-period": "^2.1.0"
+    "textlint-rule-ja-no-mixed-period": "^2.1.1"
   },
   "dependencies": {}
 }


### PR DESCRIPTION
修正版をリリースしました。
`npm install textlint-rule-ja-no-mixed-period@2.1.1` でエラーがでなくなりました。
https://github.com/textlint-ja/textlint-rule-ja-no-mixed-period/releases/tag/2.1.1